### PR TITLE
optional card holder validation

### DIFF
--- a/lib/credit_card_form.dart
+++ b/lib/credit_card_form.dart
@@ -41,6 +41,8 @@ class CreditCardForm extends StatefulWidget {
     this.isHolderNameVisible = true,
     this.isCardNumberVisible = true,
     this.isExpiryDateVisible = true,
+    this.cardHolderLength,
+    this.cardHolderValidationMessage = 'Maximum length is 30',
   }) : super(key: key);
 
   final String cardNumber;
@@ -50,6 +52,7 @@ class CreditCardForm extends StatefulWidget {
   final String cvvValidationMessage;
   final String dateValidationMessage;
   final String numberValidationMessage;
+  final String cardHolderValidationMessage;
   final void Function(CreditCardModel) onCreditCardModelChange;
   final Color themeColor;
   final Color textColor;
@@ -59,6 +62,8 @@ class CreditCardForm extends StatefulWidget {
   final bool isHolderNameVisible;
   final bool isCardNumberVisible;
   final bool isExpiryDateVisible;
+  // optional cardHolderLength param, if provided, will do validation
+  final int? cardHolderLength;
   final GlobalKey<FormState> formKey;
 
   final InputDecoration cardNumberDecoration;
@@ -317,6 +322,12 @@ class _CreditCardFormState extends State<CreditCardForm> {
                   onEditingComplete: () {
                     FocusScope.of(context).unfocus();
                     onCreditCardModelChange(creditCardModel);
+                  },
+                  validator: (String? value) {
+                    if (widget.cardHolderLength != null && value!.length > widget.cardHolderLength!) {
+                      return widget.cardHolderValidationMessage;
+                    }
+                    return null;
                   },
                 ),
               ),


### PR DESCRIPTION
optional cardHolderLength parameter, if provided, perform validation against cardHolder field and display message on violation. message is default to 'Maximum length is 30'

<img width="377" alt="image" src="https://github.com/Koroutine/flutter_credit_card/assets/49230715/5aa9aeef-8b17-493c-97c0-9fd0b1f845b8">